### PR TITLE
Specify merge strategy in release-process.md

### DIFF
--- a/documentation/release-process.md
+++ b/documentation/release-process.md
@@ -5,9 +5,10 @@
 
 ## Prepare the release branch
 
+>**Warning** when merging one branch into another, be sure to use a merge commit if there are any conflicts. Rebasing or squashing will not properly preserve the commit history and will impact release notes generation.
+
 1. Update the [internal pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=954) variables to prevent consumption of nightly builds into dotnet-docker. Set `NightlyUpdateDockerFromMain` variable to `false` on the pipeline itself, not just on a new build.
 1. Merge from the `main` branch to the appropriate release branch (e.g. `release/5.0`). Note that for patch releases, fixes should be made directly to the appropriate release branch and we do not merge from the `main` branch. Note that it is acceptable to use a release/major.x branch. Alternatively, you can create a new release branch for the minor version. See [additional branch steps](#additional-steps-when-creating-a-new-release-branch) below.
->**Warning** when merging one branch into another, be sure to use a merge commit if there are any conflicts. Rebasing or squashing will not properly preserve the commit history and will impact release notes generation.
 1. Review and merge in any outstanding dependabot PRs for the release branch.
 1. Run the [Update release version](https://github.com/dotnet/dotnet-monitor/actions/workflows/update-release-version.yml) workflow, setting `Use workflow from` to the release branch and correctly setting the `Release type` and `Release version` options. (*NOTE:* Release version should include only major.minor.patch, without any extra labels). Review and merge in the PR created by this workflow.
 1. If you merged from `main` in step 1, repeat the above step for the `main` branch with the appropriate `Release type` and `Release version`.


### PR DESCRIPTION
###### Summary

Specify that a merge commit should be used one merging one branch into another. Rebasing or squashing will rewrite the commit history (changing commit hashes), impacting release notes generation.


<!-- A single line description of the changes for the release notes. It will automatically be formatted correctly and linked to this PR. Leave blank if not needed.-->
###### Release Notes Entry
